### PR TITLE
Optimizing UAC.challenge to skip challenges

### DIFF
--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -21,6 +21,11 @@ library DataTypes {
         uint createdBlock;
     }
 
+    struct Challenge {
+        bytes challengeInput;
+        Property challengeProperty;
+    }
+
     struct Range {
         uint256 start;
         uint256 end;


### PR DESCRIPTION
updating `UAC.challenge` for skipping challenges which don't need interactiveness.

Close #32 