### PR TITLE
feat(contract): Impl removeChallenge and setPredicateDecision #39

### DIFF
--- a/contracts/Predicate/AndPredicate.sol
+++ b/contracts/Predicate/AndPredicate.sol
@@ -4,14 +4,17 @@ pragma experimental ABIEncoderV2;
 import {DataTypes as types} from "../DataTypes.sol";
 import "./LogicalConnective.sol";
 import {UniversalAdjudicationContract} from "../UniversalAdjudicationContract.sol";
+import "../Utils.sol";
 
 contract AndPredicate is LogicalConnective {
     address uacAddress;
     address notPredicateAddress;
+    Utils utils;
 
-    constructor(address _uacAddress, address _notPredicateAddress) public {
+    constructor(address _uacAddress, address _notPredicateAddress, address utilsAddress) public {
         uacAddress = _uacAddress;
         notPredicateAddress = _notPredicateAddress;
+        utils = Utils(utilsAddress);
     }
 
     struct TestPredicateInput {
@@ -43,7 +46,7 @@ contract AndPredicate is LogicalConnective {
     /**
      * @dev Can decide true when all child properties are decided true
      */
-    function decideTrue(types.Property[] memory innerProperties, bytes memory _witness) public {
+    function decideTrue(types.Property[] memory innerProperties) public {
         for (uint i = 0;i < innerProperties.length;i++) {
             require(
                 UniversalAdjudicationContract(uacAddress).isDecided(innerProperties[i]),
@@ -55,7 +58,7 @@ contract AndPredicate is LogicalConnective {
             inputs[i] = abi.encode(innerProperties[i]);
         }
         types.Property memory property = createPropertyFromInput(inputs);
-        UniversalAdjudicationContract(uacAddress).decideProperty(property, true);
+        UniversalAdjudicationContract(uacAddress).setPredicateDecision(utils.getPropertyId(property), true);
 
         emit ValueDecided(true, property);
     }

--- a/contracts/Predicate/AtomicPredicate.sol
+++ b/contracts/Predicate/AtomicPredicate.sol
@@ -4,5 +4,5 @@ pragma experimental ABIEncoderV2;
 import {DataTypes as types} from "../DataTypes.sol";
 
 interface AtomicPredicate {
-    function decideTrue(bytes[] calldata _inputs, bytes calldata _witness) external;
+    function decideTrue(bytes[] calldata _inputs) external;
 }

--- a/contracts/Predicate/NotPredicate.sol
+++ b/contracts/Predicate/NotPredicate.sol
@@ -4,12 +4,15 @@ pragma experimental ABIEncoderV2;
 import {DataTypes as types} from "../DataTypes.sol";
 import "./LogicalConnective.sol";
 import {UniversalAdjudicationContract} from "../UniversalAdjudicationContract.sol";
+import "../Utils.sol";
 
 contract NotPredicate is LogicalConnective {
     address uacAddress;
+    Utils utils;
 
-    constructor(address _uacAddress) public {
+    constructor(address _uacAddress, address utilsAddress) public {
         uacAddress = _uacAddress;
+        utils = Utils(utilsAddress);
     }
 
     struct TestPredicateInput {
@@ -37,15 +40,15 @@ contract NotPredicate is LogicalConnective {
     /**
      * @dev Decides true
      */
-    function decideTrue(types.Property memory innerProperty, bytes memory _witness) public {
+    function decideTrue(types.Property memory innerProperty) public {
         require(
-            UniversalAdjudicationContract(uacAddress).isDecided(innerProperty),
-            "This property isn't true"
+            !UniversalAdjudicationContract(uacAddress).isDecided(innerProperty),
+            "inner property must be false"
         );
         bytes[] memory inputs = new bytes[](1);
         inputs[0] = abi.encode(innerProperty);
         types.Property memory property = createPropertyFromInput(inputs);
-        UniversalAdjudicationContract(uacAddress).decideProperty(property, true);
+        UniversalAdjudicationContract(uacAddress).setPredicateDecision(utils.getPropertyId(property), true);
 
         emit ValueDecided(true, innerProperty);
     }

--- a/contracts/Predicate/TestPredicate.sol
+++ b/contracts/Predicate/TestPredicate.sol
@@ -4,12 +4,15 @@ pragma experimental ABIEncoderV2;
 import {DataTypes as types} from "../DataTypes.sol";
 import "./AtomicPredicate.sol";
 import {UniversalAdjudicationContract} from "../UniversalAdjudicationContract.sol";
+import "../Utils.sol";
 
 contract TestPredicate is AtomicPredicate {
     address uacAddress;
+    Utils utils;
 
-    constructor(address _uacAddress) public {
+    constructor(address _uacAddress, address utilsAddress) public {
         uacAddress = _uacAddress;
+        utils = Utils(utilsAddress);
     }
 
     struct TestPredicateInput {
@@ -26,12 +29,22 @@ contract TestPredicate is AtomicPredicate {
         return property;
     }
 
-    function decideTrue(bytes[] memory _inputs, bytes memory _witness) public {
+    function decideTrue(bytes[] memory _inputs) public {
         require(_inputs.length > 0, "This property is not true");
 
         types.Property memory property = createPropertyFromInput(_inputs);
-        UniversalAdjudicationContract(uacAddress).decideProperty(property, true);
+        UniversalAdjudicationContract(uacAddress).setPredicateDecision(utils.getPropertyId(property), true);
 
         emit ValueDecided(true, _inputs);
     }
+
+    function decideFalse(bytes[] memory _inputs) public {
+        require(_inputs.length == 0, "This property is not true");
+
+        types.Property memory property = createPropertyFromInput(_inputs);
+        UniversalAdjudicationContract(uacAddress).setPredicateDecision(utils.getPropertyId(property), false);
+
+        emit ValueDecided(false, _inputs);
+    }
+
 }

--- a/test/AndPredicate.test.js
+++ b/test/AndPredicate.test.js
@@ -28,9 +28,9 @@ describe('AndPredicate', () => {
 
   beforeEach(async () => {
     adjudicationContract = await deployContract(wallet, UniversalAdjudicationContract, [utils.address]);
-    notPredicate = await deployContract(wallet, NotPredicate, [adjudicationContract.address]);
-    andPredicate = await deployContract(wallet, AndPredicate, [adjudicationContract.address, notPredicate.address]);
-    testPredicate = await deployContract(wallet, TestPredicate, [adjudicationContract.address]);
+    notPredicate = await deployContract(wallet, NotPredicate, [adjudicationContract.address, utils.address]);
+    andPredicate = await deployContract(wallet, AndPredicate, [adjudicationContract.address, notPredicate.address, utils.address]);
+    testPredicate = await deployContract(wallet, TestPredicate, [adjudicationContract.address, utils.address]);
     trueProperty = {
       predicateAddress: testPredicate.address,
       inputs: ['0x01']


### PR DESCRIPTION
* impl removeChallenge
* impl setPredicateDecision


Current implementation, We have 2 ways to decide not-atomic-proposition. `decideClaimToTrue` and `setPredicateDecision` from predicate.

* `decideClaimToTrue` must be succeeded whenever over dispute period.
* For `setPredicateDecision`, each predicate can restrict rule of decision.

Basically we requires both method. but `decideClaimToTrue` is little bit un usable, because users have to challenge something that is clearly not true.
