### PR TITLE
 Support property as the variable in ForAllSuchThatQuantifier

### DIFF
--- a/contracts/Predicate/ForAllSuchThatQuantifier.sol
+++ b/contracts/Predicate/ForAllSuchThatQuantifier.sol
@@ -51,6 +51,8 @@ contract ForAllSuchThatQuantifier is LogicalConnective {
      */
     function replaceVariable(bytes memory propertyBytes, bytes memory placeholder, bytes memory quantified) private view returns(bytes memory) {
         // Support property as the variable in ForAllSuchThatQuantifier.
+        // This code enables meta operation which we were calling eval without adding specific "eval" contract.
+        // For instance, we can write a property like `∀su ∈ SU: su()`.
         if(utils.isPlaceholder(propertyBytes)) {
             if(keccak256(utils.getPlaceholderName(propertyBytes)) == keccak256(placeholder)) {
                 return quantified;

--- a/contracts/Predicate/ForAllSuchThatQuantifier.sol
+++ b/contracts/Predicate/ForAllSuchThatQuantifier.sol
@@ -50,6 +50,12 @@ contract ForAllSuchThatQuantifier is LogicalConnective {
      * @dev Replace placeholder by quantified in propertyBytes
      */
     function replaceVariable(bytes memory propertyBytes, bytes memory placeholder, bytes memory quantified) private view returns(bytes memory) {
+        // Support property as the variable in ForAllSuchThatQuantifier.
+        if(utils.isPlaceholder(propertyBytes)) {
+            if(keccak256(utils.getPlaceholderName(propertyBytes)) == keccak256(placeholder)) {
+                return quantified;
+            }
+        }
         types.Property memory property = abi.decode(propertyBytes, (types.Property));
         if(property.predicateAddress == notPredicateAddress) {
             property.inputs[0] = replaceVariable(property.inputs[0], placeholder, quantified);


### PR DESCRIPTION
Close #57 

## What I wanna archive in this PR

This PR enables meta operation which we were calling `eval` without adding specific "eval" contract. For instance, we can write a property like below.

```
∀su ∈ SU: su()
```