### PR TITLE
adding IsValidStateTransitionPredicate

### DIFF
--- a/contracts/Predicate/Atomic/IsContainedPredicate.sol
+++ b/contracts/Predicate/Atomic/IsContainedPredicate.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import {DataTypes as types} from "../../DataTypes.sol";
+import {UniversalAdjudicationContract} from "../../UniversalAdjudicationContract.sol";
+import "../AtomicPredicate.sol";
+import "../../Utils.sol";
+
+contract IsContainedPredicate is AtomicPredicate {
+    UniversalAdjudicationContract adjudicationContract;
+    Utils utils;
+
+    constructor(address _uacAddress, address _utilsAddress) public {
+        adjudicationContract = UniversalAdjudicationContract(_uacAddress);
+        utils = Utils(_utilsAddress);
+    }
+
+    function decide(bytes[] memory _inputs) public pure returns (bool) {
+        types.Range memory range = abi.decode(_inputs[0], (types.Range));
+        types.Range memory subrange = abi.decode(_inputs[1], (types.Range));
+        require(range.start <= subrange.start && subrange.end <= range.end, "range must contain subrange");
+        return true;
+    }
+
+    function decideTrue(bytes[] memory _inputs) public {
+        require(decide(_inputs), "must decide true");
+        types.Property memory property = types.Property({
+            predicateAddress: address(this),
+            inputs: _inputs
+        });
+        adjudicationContract.setPredicateDecision(utils.getPropertyId(property), true);
+    }
+}

--- a/contracts/Predicate/Standard/IsValidStateTransitionPredicate.sol
+++ b/contracts/Predicate/Standard/IsValidStateTransitionPredicate.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import {DataTypes as types} from "../../DataTypes.sol";
+import "../AtomicPredicate.sol";
+import {UniversalAdjudicationContract} from "../../UniversalAdjudicationContract.sol";
+import "../../Utils.sol";
+
+/**
+ * IsValidStateTransitionPredicate stands for the claim below.
+ * def IsValidStateTransition(prev_su, tx, su) :=
+ *   eq(tx.adderss, Tx.address)
+ *   and eq(tx.0, prev_su.0)
+ *   and within(tx.1, prev_su.1)
+ *   and eq(tx.2, prev_su.2)
+ *   and eq(tx.3, su.3)
+ */
+contract IsValidStateTransitionPredicate is AtomicPredicate {
+    UniversalAdjudicationContract adjudicationContract;
+    Utils utils;
+    address txAddress;
+
+    constructor(address _uacAddress, address _utilsAddress, address _txAddress) public {
+        adjudicationContract = UniversalAdjudicationContract(_uacAddress);
+        utils = Utils(_utilsAddress);
+        txAddress = _txAddress;
+    }
+
+    function decide(bytes[] memory _inputs) public view returns (bool) {
+        types.Property memory previousStateUpdate = abi.decode(_inputs[0], (types.Property));
+        types.Property memory transaction = abi.decode(_inputs[1], (types.Property));
+        types.Property memory stateUpdate = abi.decode(_inputs[2], (types.Property));
+        require(transaction.predicateAddress == txAddress, "transaction.predicateAddress must be Tx.address");
+        require(keccak256(transaction.inputs[0]) == keccak256(previousStateUpdate.inputs[0]), "token must be same");
+        require(keccak256(transaction.inputs[1]) == keccak256(previousStateUpdate.inputs[1]), "range must be same");
+        require(keccak256(transaction.inputs[2]) == keccak256(previousStateUpdate.inputs[2]), "input block number must be same");
+        require(keccak256(transaction.inputs[3]) == keccak256(stateUpdate.inputs[3]), "state object must be same");
+        return true;
+    }
+
+    function decideTrue(bytes[] memory _inputs) public {
+        require(decide(_inputs), "must decide true");
+        types.Property memory property = types.Property({
+            predicateAddress: address(this),
+            inputs: _inputs
+        });
+        adjudicationContract.setPredicateDecision(utils.getPropertyId(property), true);
+    }
+}

--- a/contracts/Predicate/Standard/IsValidStateTransitionPredicate.sol
+++ b/contracts/Predicate/Standard/IsValidStateTransitionPredicate.sol
@@ -5,6 +5,7 @@ import {DataTypes as types} from "../../DataTypes.sol";
 import "../AtomicPredicate.sol";
 import {UniversalAdjudicationContract} from "../../UniversalAdjudicationContract.sol";
 import "../../Utils.sol";
+import "../Atomic/IsContainedPredicate.sol";
 
 /**
  * IsValidStateTransitionPredicate stands for the claim below.
@@ -19,20 +20,30 @@ contract IsValidStateTransitionPredicate is AtomicPredicate {
     UniversalAdjudicationContract adjudicationContract;
     Utils utils;
     address txAddress;
+    IsContainedPredicate isContainedPredicate;
 
-    constructor(address _uacAddress, address _utilsAddress, address _txAddress) public {
+    constructor(
+        address _uacAddress,
+        address _utilsAddress,
+        address _txAddress,
+        address _isContainedPredicateAddress
+    ) public {
         adjudicationContract = UniversalAdjudicationContract(_uacAddress);
         utils = Utils(_utilsAddress);
         txAddress = _txAddress;
+        isContainedPredicate = IsContainedPredicate(_isContainedPredicateAddress);
     }
 
     function decide(bytes[] memory _inputs) public view returns (bool) {
         types.Property memory previousStateUpdate = abi.decode(_inputs[0], (types.Property));
         types.Property memory transaction = abi.decode(_inputs[1], (types.Property));
         types.Property memory stateUpdate = abi.decode(_inputs[2], (types.Property));
+        bytes[] memory inputsForIsContained = new bytes[](2);
+        inputsForIsContained[0] = transaction.inputs[1];
+        inputsForIsContained[1] = previousStateUpdate.inputs[1];
         require(transaction.predicateAddress == txAddress, "transaction.predicateAddress must be Tx.address");
         require(keccak256(transaction.inputs[0]) == keccak256(previousStateUpdate.inputs[0]), "token must be same");
-        require(keccak256(transaction.inputs[1]) == keccak256(previousStateUpdate.inputs[1]), "range must be same");
+        require(isContainedPredicate.decide(inputsForIsContained), "range must be included");
         require(keccak256(transaction.inputs[2]) == keccak256(previousStateUpdate.inputs[2]), "input block number must be same");
         require(keccak256(transaction.inputs[3]) == keccak256(stateUpdate.inputs[3]), "state object must be same");
         return true;

--- a/contracts/UniversalAdjudicationContract.sol
+++ b/contracts/UniversalAdjudicationContract.sol
@@ -133,6 +133,10 @@ contract UniversalAdjudicationContract {
         return instantiatedGames[utils.getPropertyId(_property)].decision == types.Decision.True;
     }
 
+    function isDecidedById(bytes32 _propertyId) public view returns (bool) {
+        return instantiatedGames[_propertyId].decision == types.Decision.True;
+    }
+
     function getGame(bytes32 claimId) public view returns (types.ChallengeGame memory) {
         return instantiatedGames[claimId];
     }

--- a/contracts/test/MockStateUpdatePredicate.sol
+++ b/contracts/test/MockStateUpdatePredicate.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import { AtomicPredicate } from "../Predicate/AtomicPredicate.sol";
+
+/**
+ * @title MockStateUpdatePredicate
+ * @notice Mock of state update predicate
+ */
+contract MockStateUpdatePredicate is AtomicPredicate {
+    constructor() public {
+    }
+    function decideTrue(bytes[] calldata _inputs) external {
+    }
+}

--- a/contracts/test/MockTxPredicate.sol
+++ b/contracts/test/MockTxPredicate.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.0;
+pragma experimental ABIEncoderV2;
+
+import { AtomicPredicate } from "../Predicate/AtomicPredicate.sol";
+
+/**
+ * @title MockTxPredicate
+ * @notice Mock of tx predicate
+ */
+contract MockTxPredicate is AtomicPredicate {
+    constructor() public {
+    }
+    function decideTrue(bytes[] calldata _inputs) external {
+    }
+}

--- a/test/predicate/standard/IsValidStateTransitionPredicate.test.ts
+++ b/test/predicate/standard/IsValidStateTransitionPredicate.test.ts
@@ -1,0 +1,127 @@
+import chai from 'chai'
+import {
+  createMockProvider,
+  deployContract,
+  getWallets,
+  solidity,
+  link
+} from 'ethereum-waffle'
+import * as MockAdjudicationContract from '../../../build/MockAdjudicationContract.json'
+import * as Utils from '../../../build/Utils.json'
+import * as IsValidStateTransitionPredicate from '../../../build/IsValidStateTransitionPredicate.json'
+import * as MockTxPredicate from '../../../build/MockTxPredicate.json'
+import * as MockStateUpdatePredicate from '../../../build/MockStateUpdatePredicate.json'
+import * as ethers from 'ethers'
+const abi = new ethers.utils.AbiCoder()
+
+chai.use(solidity)
+chai.use(require('chai-as-promised'))
+const { expect, assert } = chai
+
+describe('IsValidStateTransition', () => {
+  let provider = createMockProvider()
+  let wallets = getWallets(provider)
+  let wallet = wallets[0]
+  let isValidStateTransitionPredicate: ethers.Contract
+  let adjudicationContract: ethers.Contract
+  let txPredicate: ethers.Contract
+  let stateUpdatePredicate: ethers.Contract
+
+  beforeEach(async () => {
+    const utils = await deployContract(wallet, Utils, [])
+    txPredicate = await deployContract(wallet, MockTxPredicate, [])
+    stateUpdatePredicate = await deployContract(
+      wallet,
+      MockStateUpdatePredicate,
+      []
+    )
+    adjudicationContract = await deployContract(
+      wallet,
+      MockAdjudicationContract,
+      [utils.address]
+    )
+    isValidStateTransitionPredicate = await deployContract(
+      wallet,
+      IsValidStateTransitionPredicate,
+      [adjudicationContract.address, utils.address, txPredicate.address]
+    )
+  })
+
+  describe('decide', () => {
+    const token = ethers.constants.AddressZero
+    const range = abi.encode(['tuple(uint256, uint256)'], [[100, 200]])
+    const previousBlockNumber = abi.encode(['uint256'], [30])
+    const blockNumber = abi.encode(['uint256'], [60])
+    const previousOwner = wallets[0].address
+    const owner = wallets[1].address
+    let prevSu: string
+    let tx: string
+    let su: string
+
+    beforeEach(() => {
+      const previousStateObject = abi.encode(
+        ['tuple(address, bytes[])'],
+        [[stateUpdatePredicate.address, [previousOwner]]]
+      )
+      const stateObject = abi.encode(
+        ['tuple(address, bytes[])'],
+        [[stateUpdatePredicate.address, [owner]]]
+      )
+      prevSu = abi.encode(
+        ['tuple(address, bytes[])'],
+        [
+          [
+            stateUpdatePredicate.address,
+            [token, range, previousBlockNumber, previousStateObject]
+          ]
+        ]
+      )
+      tx = abi.encode(
+        ['tuple(address, bytes[])'],
+        [
+          [
+            txPredicate.address,
+            [token, range, previousBlockNumber, stateObject]
+          ]
+        ]
+      )
+      su = abi.encode(
+        ['tuple(address, bytes[])'],
+        [
+          [
+            stateUpdatePredicate.address,
+            [token, range, blockNumber, stateObject]
+          ]
+        ]
+      )
+    })
+
+    it('suceed to decide', async () => {
+      const result = await isValidStateTransitionPredicate.decide([
+        prevSu,
+        tx,
+        su
+      ])
+      expect(result).to.be.true
+    })
+
+    it('fail to decide with invalid transaction', async () => {
+      const stateObject = abi.encode(
+        ['tuple(address, bytes[])'],
+        [[stateUpdatePredicate.address, [wallets[2].address]]]
+      )
+      const invalidTx = abi.encode(
+        ['tuple(address, bytes[])'],
+        [
+          [
+            txPredicate.address,
+            [token, range, previousBlockNumber, stateObject]
+          ]
+        ]
+      )
+      await expect(
+        isValidStateTransitionPredicate.decide([prevSu, invalidTx, su])
+      ).to.be.revertedWith('state object must be same')
+    })
+  })
+})

--- a/test/predicate/standard/IsValidStateTransitionPredicate.test.ts
+++ b/test/predicate/standard/IsValidStateTransitionPredicate.test.ts
@@ -11,6 +11,7 @@ import * as Utils from '../../../build/Utils.json'
 import * as IsValidStateTransitionPredicate from '../../../build/IsValidStateTransitionPredicate.json'
 import * as MockTxPredicate from '../../../build/MockTxPredicate.json'
 import * as MockStateUpdatePredicate from '../../../build/MockStateUpdatePredicate.json'
+import * as IsContainedPredicate from '../../../build/IsContainedPredicate.json'
 import * as ethers from 'ethers'
 const abi = new ethers.utils.AbiCoder()
 
@@ -26,6 +27,7 @@ describe('IsValidStateTransition', () => {
   let adjudicationContract: ethers.Contract
   let txPredicate: ethers.Contract
   let stateUpdatePredicate: ethers.Contract
+  let isContainedPredicate: ethers.Contract
 
   beforeEach(async () => {
     const utils = await deployContract(wallet, Utils, [])
@@ -40,10 +42,19 @@ describe('IsValidStateTransition', () => {
       MockAdjudicationContract,
       [utils.address]
     )
+    isContainedPredicate = await deployContract(wallet, IsContainedPredicate, [
+      adjudicationContract.address,
+      utils.address
+    ])
     isValidStateTransitionPredicate = await deployContract(
       wallet,
       IsValidStateTransitionPredicate,
-      [adjudicationContract.address, utils.address, txPredicate.address]
+      [
+        adjudicationContract.address,
+        utils.address,
+        txPredicate.address,
+        isContainedPredicate.address
+      ]
     )
   })
 


### PR DESCRIPTION
Adding IsValidStateTransitionPredicate to validate state transition. It's for limbo exit.

```py
def LimboExit(prev_su, tx, su) :=
  exit(prev_su)
  or (
    prev_su()
    and IsValidStateTransition(prev_su, tx, su)
    and exit(su))
```