### PR TITLE
add makeTrueDecisionFromTrueGame method to UAC

### DIFF
--- a/contracts/DataTypes.sol
+++ b/contracts/DataTypes.sol
@@ -21,6 +21,11 @@ library DataTypes {
         uint createdBlock;
     }
 
+    struct Challenge {
+        bytes challengeInput;
+        Property challengeProperty;
+    }
+
     struct Range {
         uint256 start;
         uint256 end;

--- a/contracts/UniversalAdjudicationContract.sol
+++ b/contracts/UniversalAdjudicationContract.sol
@@ -128,7 +128,7 @@ contract UniversalAdjudicationContract {
     ) public {
         types.ChallengeGame storage game = instantiatedGames[_gameId];
         types.ChallengeGame memory conditionGame = instantiatedGames[_conditionGameId];
-        require(_challenges.length % 2 == 0, "a number of challenges must be even");
+        require(_challenges.length % 2 == 0, "the number of challenges must be even");
         require(verifyChildOfGameTree(game.property, _challenges, _conditionGameId, 0), "_conditionGameId must be valid child of game tree");
         require(conditionGame.decision == types.Decision.True, "condition property must be true");
         game.decision = types.Decision.True;
@@ -157,7 +157,7 @@ contract UniversalAdjudicationContract {
             // Counter parties' turn can be skipped if challenge.challengeInput is empty.
             if(i % 2 == 0) {
                 require(
-                    keccak256(challenges[i + isChallenge].challengeInput) == keccak256(abi.encodePacked(byte(0))),
+                    keccak256(challenges[i + isChallenge].challengeInput) == keccak256(bytes("")),
                     "challengeInput must be empty"
                 );
             }

--- a/test/AndPredicate.test.ts
+++ b/test/AndPredicate.test.ts
@@ -114,5 +114,10 @@ describe('AndPredicate', () => {
         )
       ).to.be.reverted
     })
+    it('throw exception with empty challengeInput', async () => {
+      await expect(
+        mockChallenge.isValidChallenge(andProperty, '0x', notFalseProperty)
+      ).to.be.reverted
+    })
   })
 })

--- a/test/UniversalDecisionContract.test.ts
+++ b/test/UniversalDecisionContract.test.ts
@@ -40,7 +40,8 @@ describe('UniversalAdjudicationContract', () => {
     adjudicationContract = await deployContract(
       wallet,
       UniversalAdjudicationContract,
-      [utils.address]
+      [utils.address],
+      { gasPrice: 8000000000, gasLimit: 4700000 }
     )
     notPredicate = await deployContract(wallet, NotPredicate, [
       adjudicationContract.address,
@@ -101,7 +102,11 @@ describe('UniversalAdjudicationContract', () => {
       await adjudicationContract.claimProperty(trueProperty)
       const gameId = getGameIdFromProperty(notProperty)
       const challengingGameId = getGameIdFromProperty(trueProperty)
-      await adjudicationContract.challenge(gameId, ['0x'], challengingGameId)
+      await adjudicationContract.challenge(
+        gameId,
+        [['0x', trueProperty]],
+        challengingGameId
+      )
       const game = await adjudicationContract.getGame(gameId)
 
       assert.equal(game.challenges.length, 1)
@@ -112,7 +117,11 @@ describe('UniversalAdjudicationContract', () => {
       const gameId = getGameIdFromProperty(notProperty)
       const challengingGameId = getGameIdFromProperty(notFalseProperty)
       await expect(
-        adjudicationContract.challenge(gameId, ['0x'], challengingGameId)
+        adjudicationContract.challenge(
+          gameId,
+          [['0x', notFalseProperty]],
+          challengingGameId
+        )
       ).to.be.reverted
     })
   })
@@ -123,7 +132,11 @@ describe('UniversalAdjudicationContract', () => {
       await adjudicationContract.claimProperty(trueProperty)
       const gameId = getGameIdFromProperty(notProperty)
       const challengingGameId = getGameIdFromProperty(trueProperty)
-      await adjudicationContract.challenge(gameId, ['0x'], challengingGameId)
+      await adjudicationContract.challenge(
+        gameId,
+        [['0x', trueProperty]],
+        challengingGameId
+      )
       await testPredicate.decideTrue(['0x01'])
       await adjudicationContract.decideClaimToFalse(gameId, challengingGameId)
       const game = await adjudicationContract.getGame(gameId)
@@ -135,7 +148,11 @@ describe('UniversalAdjudicationContract', () => {
       await adjudicationContract.claimProperty(falseProperty)
       const gameId = getGameIdFromProperty(notFalseProperty)
       const challengingGameId = getGameIdFromProperty(falseProperty)
-      await adjudicationContract.challenge(gameId, ['0x'], challengingGameId)
+      await adjudicationContract.challenge(
+        gameId,
+        [['0x', falseProperty]],
+        challengingGameId
+      )
       await expect(
         adjudicationContract.decideClaimToFalse(gameId, challengingGameId)
       ).to.be.reverted
@@ -192,7 +209,11 @@ describe('UniversalAdjudicationContract', () => {
       await adjudicationContract.claimProperty(falseProperty)
       const gameId = getGameIdFromProperty(notFalseProperty)
       const challengeGameId = getGameIdFromProperty(falseProperty)
-      await adjudicationContract.challenge(gameId, ['0x'], challengeGameId)
+      await adjudicationContract.challenge(
+        gameId,
+        [['0x', falseProperty]],
+        challengeGameId
+      )
       await testPredicate.decideFalse(falseProperty.inputs)
       await adjudicationContract.removeChallenge(gameId, challengeGameId)
       const game = await adjudicationContract.getGame(gameId)
@@ -203,7 +224,11 @@ describe('UniversalAdjudicationContract', () => {
       await adjudicationContract.claimProperty(falseProperty)
       const gameId = getGameIdFromProperty(notFalseProperty)
       const challengeGameId = getGameIdFromProperty(falseProperty)
-      await adjudicationContract.challenge(gameId, ['0x'], challengeGameId)
+      await adjudicationContract.challenge(
+        gameId,
+        [['0x', falseProperty]],
+        challengeGameId
+      )
       await expect(
         adjudicationContract.removeChallenge(gameId, challengeGameId)
       ).to.be.reverted
@@ -213,7 +238,11 @@ describe('UniversalAdjudicationContract', () => {
       await adjudicationContract.claimProperty(trueProperty)
       const gameId = getGameIdFromProperty(notProperty)
       const challengeGameId = getGameIdFromProperty(trueProperty)
-      await adjudicationContract.challenge(gameId, ['0x'], challengeGameId)
+      await adjudicationContract.challenge(
+        gameId,
+        [['0x', trueProperty]],
+        challengeGameId
+      )
       await testPredicate.decideTrue(trueProperty.inputs)
       await expect(
         adjudicationContract.removeChallenge(gameId, challengeGameId)


### PR DESCRIPTION
### Why

To make true decision for `∃x ∈ X : p(x)` from `p(x_0)`.

### What

adding makeTrueDecisionFromTrueGame method to decide a property from a true condition that is a child of the property.

Close #64
