### PR TITLE
add isDecidable to adjudication contract

### DIFF
--- a/contracts/UniversalAdjudicationContract.sol
+++ b/contracts/UniversalAdjudicationContract.sol
@@ -56,21 +56,8 @@ contract UniversalAdjudicationContract {
      * @dev Sets the game decision true when its dispute period has already passed.
      */
     function decideClaimToTrue(bytes32 _gameId) public {
+        require(isDecidable(_gameId), "claim should be decidable");
         types.ChallengeGame storage game = instantiatedGames[_gameId];
-        // check all _game.challenges should be false
-        for (uint256 i = 0; i < game.challenges.length; i++) {
-            types.ChallengeGame memory challengingGame = instantiatedGames[game
-                .challenges[i]];
-            require(
-                challengingGame.decision == types.Decision.False,
-                "all _game.challenges must be false"
-            );
-        }
-        // should check dispute period
-        require(
-            game.createdBlock < block.number - DISPUTE_PERIOD,
-            "Dispute period haven't passed yet."
-        );
         // game should be decided true
         game.decision = types.Decision.True;
         emit ClaimDecided(_gameId, true);

--- a/contracts/UniversalAdjudicationContract.sol
+++ b/contracts/UniversalAdjudicationContract.sol
@@ -219,6 +219,23 @@ contract UniversalAdjudicationContract {
             types.Decision.True;
     }
 
+    function isDecidable(bytes32 _propertyId) public view returns (bool) {
+        types.ChallengeGame storage game = instantiatedGames[_propertyId];
+        if (game.createdBlock > block.number - DISPUTE_PERIOD) {
+            return false;
+        }
+
+        // check all _game.challenges should be false
+        for (uint256 i = 0; i < game.challenges.length; i++) {
+            types.ChallengeGame memory challengingGame = instantiatedGames[game
+                .challenges[i]];
+            if (challengingGame.decision != types.Decision.False) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     function isDecidedById(bytes32 _propertyId) public view returns (bool) {
         return instantiatedGames[_propertyId].decision == types.Decision.True;
     }

--- a/test/UniversalAdjudicationContract.test.ts
+++ b/test/UniversalAdjudicationContract.test.ts
@@ -508,4 +508,32 @@ describe('UniversalAdjudicationContract', () => {
       ).to.be.reverted
     })
   })
+
+  describe('isDecidable', () => {
+    it('returns false when dispute period has not passed yet', async () => {
+      await adjudicationContract.claimProperty(trueProperty)
+      const gameId = getGameIdFromProperty(trueProperty)
+      const decidable = await adjudicationContract.isDecidable(gameId)
+      expect(decidable).false
+    })
+
+    it('returns false when challenge is not empty', async () => {
+      await adjudicationContract.claimProperty(notProperty)
+      await adjudicationContract.claimProperty(trueProperty)
+      const gameId = getGameIdFromProperty(notProperty)
+      const challengeGameId = getGameIdFromProperty(trueProperty)
+      await adjudicationContract.challenge(gameId, ['0x'], challengeGameId)
+
+      const decidable = await adjudicationContract.isDecidable(gameId)
+      expect(decidable).false
+    })
+
+    it('returns true when dispute period has passed and no challenge remains', async () => {
+      await adjudicationContract.claimProperty(trueProperty)
+      const gameId = getGameIdFromProperty(trueProperty)
+      await increaseBlocks(wallets, 7)
+      const decidable = await adjudicationContract.isDecidable(gameId)
+      expect(decidable).true
+    })
+  })
 })


### PR DESCRIPTION
`isDecidable` method checks if given property is decidable.
Clients use this method before calling `decide` method in order to prevent waste their gas.